### PR TITLE
Add support for fetching projects by path (name)

### DIFF
--- a/docs/data-sources/workflows_project.md
+++ b/docs/data-sources/workflows_project.md
@@ -1,39 +1,50 @@
 # firefly_workflows_project (Data Source)
 
-Fetches a single Firefly project by ID.
+Fetches a single Firefly project by ID or path (name).
 
 ## Example Usage
 
 ```terraform
-data "firefly_workflows_project" "main" {
+# Fetch project by ID
+data "firefly_workflows_project" "by_id" {
   id = "existing-project-id"
+}
+
+# Fetch project by path (name)  
+data "firefly_workflows_project" "by_path" {
+  path = "Production Infrastructure"
 }
 
 # Use the project data
 resource "firefly_workflows_runners_workspace" "app" {
   name       = "new-app"
-  project_id = data.firefly_workflows_project.main.id
+  project_id = data.firefly_workflows_project.by_path.id
   # ... other configuration
 }
 
 # Output project information
 output "project_info" {
   value = {
-    name            = data.firefly_workflows_project.main.name
-    description     = data.firefly_workflows_project.main.description
-    workspace_count = data.firefly_workflows_project.main.workspace_count
+    id              = data.firefly_workflows_project.by_path.id
+    path            = data.firefly_workflows_project.by_path.path
+    name            = data.firefly_workflows_project.by_path.name
+    description     = data.firefly_workflows_project.by_path.description
+    workspace_count = data.firefly_workflows_project.by_path.workspace_count
   }
 }
 ```
 
 ## Schema
 
-### Required
+### Optional (exactly one required)
 
 - `id` (String) - The unique identifier of the project
+- `path` (String) - The path (name) of the project
 
 ### Read-Only
 
+- `id` (String) - The unique identifier of the project (computed when using path)
+- `path` (String) - The path (name) of the project (computed when using id)  
 - `name` (String) - The name of the project
 - `description` (String) - The description of the project
 - `labels` (List of String) - Labels assigned to the project

--- a/examples/data-sources/firefly_workflows_project_by_path/data-source.tf
+++ b/examples/data-sources/firefly_workflows_project_by_path/data-source.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_providers {
+    firefly = {
+      source = "gofireflyio/firefly"
+      version = "~> 0.0.1"
+    }
+  }
+}
+
+# Fetch project by path (name)
+data "firefly_workflows_project" "by_path" {
+  path = "Production Infrastructure"
+}
+
+# Output the fetched project details
+output "project_details" {
+  value = {
+    id              = data.firefly_workflows_project.by_path.id
+    path            = data.firefly_workflows_project.by_path.path
+    name            = data.firefly_workflows_project.by_path.name
+    description     = data.firefly_workflows_project.by_path.description
+    workspace_count = data.firefly_workflows_project.by_path.workspace_count
+    members_count   = data.firefly_workflows_project.by_path.members_count
+  }
+}


### PR DESCRIPTION
## Summary
- Extended `firefly_workflows_project` data source to accept either `id` or `path` parameter
- Path parameter allows fetching projects by name instead of requiring the ID
- Added validation to ensure exactly one of id/path is provided

## Changes
- Modified data source schema to include optional `path` field
- Updated Read logic to search projects by name when path is provided
- Added comprehensive documentation and examples
- Maintains backward compatibility - existing usage by ID continues to work

## Example Usage
```terraform
# New: Fetch by path/name
data "firefly_workflows_project" "prod" {
  path = "Production Infrastructure"
}

# Existing: Fetch by ID (still works)
data "firefly_workflows_project" "main" {
  id = "project-123"
}
```

## Test Plan
- [x] Schema validation for conflicting id/path parameters
- [x] Project lookup by name using ListProjects search
- [x] Backward compatibility with existing ID-based lookups
- [x] Documentation updated with examples

🤖 Generated with [Claude Code](https://claude.ai/code)