### PR TITLE
Add manual trigger option to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to release.yml to enable manual releases from GitHub Actions UI
- Allows triggering releases without creating new git tags
- Useful for hotfixes and on-demand release management

## Test plan
- [ ] Verify workflow can be triggered manually from GitHub Actions UI
- [ ] Confirm existing tag-based triggers still work as expected
- [ ] Test that manual triggers produce proper releases

🤖 Generated with [Claude Code](https://claude.ai/code)