### PR TITLE
INFL-18723: Update Backup & DR client to match updated OpenAPI spec

### DIFF
--- a/firefly-test/main.tf
+++ b/firefly-test/main.tf
@@ -22,40 +22,14 @@ variable "secret_key" {
   sensitive = true
 }
 
-# Test: Backup & DR Application with Monthly last_day schedule
-# This reproduces the cron_expression inconsistency bug fix
-resource "firefly_backup_and_dr_application" "monthly_last_day" {
-  account_id     = "66169d5af4992fc0bab04510"
-  application_name = "terraform-test-monthly-last-day"
-  integration_id = "692ec8acce65b3dc46cfceb5"
-  region         = "eu-west-1"
-  provider_type  = "aws"
-
-  schedule {
-    frequency             = "Monthly"
-    monthly_schedule_type = "last_day"
-  }
-
-  scope {
-    type  = "tags"
-    value = ["terraform-test:true"]
-  }
-}
-
-# Test: Backup & DR Application with Daily schedule
-resource "firefly_backup_and_dr_application" "daily_backup" {
+# Test: Backup & DR Application with 24-hour backup frequency
+resource "firefly_backup_and_dr_application" "daily_equivalent" {
   account_id       = "66169d5af4992fc0bab04510"
-  application_name = "terraform-test-daily"
+  application_name = "terraform-test-24h"
   integration_id   = "692ec8acce65b3dc46cfceb5"
   region           = "eu-west-1"
   provider_type    = "aws"
-  description      = "Daily backup test"
-
-  schedule {
-    frequency = "Daily"
-    hour      = 2
-    minute    = 30
-  }
+  frequency        = 24
 
   scope {
     type  = "tags"
@@ -63,3 +37,18 @@ resource "firefly_backup_and_dr_application" "daily_backup" {
   }
 }
 
+# Test: Backup & DR Application with 8-hour backup frequency
+resource "firefly_backup_and_dr_application" "frequent_backup" {
+  account_id       = "66169d5af4992fc0bab04510"
+  application_name = "terraform-test-8h"
+  integration_id   = "692ec8acce65b3dc46cfceb5"
+  region           = "eu-west-1"
+  provider_type    = "aws"
+  description      = "Frequent backup test"
+  frequency        = 8
+
+  scope {
+    type  = "tags"
+    value = ["Demo: BackupDR"]
+  }
+}

--- a/internal/client/backup_and_dr.go
+++ b/internal/client/backup_and_dr.go
@@ -15,70 +15,69 @@ type BackupAndDrService struct {
 
 // PolicyCreateRequest represents a backup policy for API requests (POST)
 type PolicyCreateRequest struct {
-	PolicyName          string         `json:"policy_name"`
-	IntegrationID       string         `json:"integration_id"`
-	Region              string         `json:"region"`
-	ProviderType        string         `json:"provider_type"`
-	Schedule            ScheduleConfig `json:"schedule"`
-	Description         string         `json:"description,omitempty"`
-	Scope               []ScopeConfig  `json:"scope,omitempty"`
-	NotificationID      string         `json:"notificationId,omitempty"`
-	VCS                 *VCSConfig     `json:"vcs,omitempty"`
-	RestoreInstructions string         `json:"restore_instructions,omitempty"`
-	BackupOnSave        bool           `json:"backup_on_save,omitempty"`
+	PolicyName          string        `json:"policy_name"`
+	IntegrationID       string        `json:"integration_id"`
+	Region              string        `json:"region"`
+	ProviderType        string        `json:"provider_type"`
+	Frequency           int           `json:"frequency,omitempty"`
+	Description         string        `json:"description,omitempty"`
+	Scope               []ScopeConfig `json:"scope,omitempty"`
+	NotificationID      string        `json:"notificationId,omitempty"`
+	VCS                 *VCSConfig    `json:"vcs,omitempty"`
+	RestoreInstructions string        `json:"restore_instructions,omitempty"`
+	BackupOnSave        bool          `json:"backup_on_save,omitempty"`
+	TargetAccount       string        `json:"target_account,omitempty"`
+	TargetRegion        string        `json:"target_region,omitempty"`
+	AutoCreatePR        bool          `json:"auto_create_pr,omitempty"`
+	ResilienceEnabled   bool          `json:"resilience_enabled,omitempty"`
 }
 
 // PolicyUpdateRequest represents a backup policy update for API requests (PUT)
 // All fields are optional to support partial updates
 type PolicyUpdateRequest struct {
-	PolicyName          *string         `json:"policy_name,omitempty"`
-	IntegrationID       *string         `json:"integration_id,omitempty"`
-	Region              *string         `json:"region,omitempty"`
-	ProviderType        *string         `json:"provider_type,omitempty"`
-	Schedule            *ScheduleConfig `json:"schedule,omitempty"`
-	Description         *string         `json:"description,omitempty"`
-	Scope               []ScopeConfig   `json:"scope,omitempty"`
-	NotificationID      *string         `json:"notificationId,omitempty"`
-	VCS                 *VCSConfig      `json:"vcs,omitempty"`
-	RestoreInstructions *string         `json:"restore_instructions,omitempty"`
-	BackupOnSave        *bool           `json:"backup_on_save,omitempty"`
+	PolicyName          *string       `json:"policy_name,omitempty"`
+	IntegrationID       *string       `json:"integration_id,omitempty"`
+	Region              *string       `json:"region,omitempty"`
+	ProviderType        *string       `json:"provider_type,omitempty"`
+	Frequency           *int          `json:"frequency,omitempty"`
+	Description         *string       `json:"description,omitempty"`
+	Scope               []ScopeConfig `json:"scope,omitempty"`
+	NotificationID      *string       `json:"notificationId,omitempty"`
+	VCS                 *VCSConfig    `json:"vcs,omitempty"`
+	RestoreInstructions *string       `json:"restore_instructions,omitempty"`
+	BackupOnSave        *bool         `json:"backup_on_save,omitempty"`
+	TargetAccount       *string       `json:"target_account,omitempty"`
+	TargetRegion        *string       `json:"target_region,omitempty"`
+	AutoCreatePR        *bool         `json:"auto_create_pr,omitempty"`
+	ResilienceEnabled   *bool         `json:"resilience_enabled,omitempty"`
 }
 
 // PolicyResponse represents a backup policy from API responses
 type PolicyResponse struct {
-	PolicyID             string         `json:"policy_id"`
-	AccountID            string         `json:"account_id"`
-	PolicyName           string         `json:"policy_name"`
-	IntegrationID        string         `json:"integration_id"`
-	Region               string         `json:"region"`
-	ProviderType         string         `json:"provider_type"`
-	Schedule             ScheduleConfig `json:"schedule"`
-	Description          string         `json:"description,omitempty"`
-	Scope                []ScopeConfig  `json:"scope,omitempty"`
-	NotificationID       string         `json:"notificationId,omitempty"`
-	VCS                  *VCSConfig     `json:"vcs,omitempty"`
-	RestoreInstructions  string         `json:"restore_instructions,omitempty"`
-	Status               string         `json:"status"`
-	SnapshotsCount       int            `json:"snapshots_count"`
-	LastBackupSnapshotID string         `json:"last_backup_snapshot_id,omitempty"`
-	LastBackupTime       string         `json:"last_backup_time,omitempty"`
-	LastBackupStatus     string         `json:"last_backup_status,omitempty"`
-	NextBackupTime       string         `json:"next_backup_time,omitempty"`
-	CreatedAt            string         `json:"created_at"`
-	UpdatedAt            string         `json:"updated_at"`
-}
-
-// ScheduleConfig represents the backup schedule configuration
-type ScheduleConfig struct {
-	Frequency           string   `json:"frequency"`
-	Hour                int      `json:"hour,omitempty"`
-	Minute              int      `json:"minute,omitempty"`
-	DaysOfWeek          []string `json:"days_of_week,omitempty"`
-	MonthlyScheduleType string   `json:"monthly_schedule_type,omitempty"`
-	DayOfMonth          int      `json:"day_of_month,omitempty"`
-	WeekdayOrdinal      string   `json:"weekday_ordinal,omitempty"`
-	WeekdayName         string   `json:"weekday_name,omitempty"`
-	CronExpression      string   `json:"cron_expression,omitempty"`
+	PolicyID             string        `json:"policy_id"`
+	AccountID            string        `json:"account_id"`
+	PolicyName           string        `json:"policy_name"`
+	IntegrationID        string        `json:"integration_id"`
+	Region               string        `json:"region"`
+	ProviderType         string        `json:"provider_type"`
+	Frequency            int           `json:"frequency"`
+	Description          string        `json:"description,omitempty"`
+	Scope                []ScopeConfig `json:"scope,omitempty"`
+	NotificationID       string        `json:"notificationId,omitempty"`
+	VCS                  *VCSConfig    `json:"vcs,omitempty"`
+	RestoreInstructions  string        `json:"restore_instructions,omitempty"`
+	Status               string        `json:"status"`
+	SnapshotsCount       int           `json:"snapshots_count"`
+	LastBackupSnapshotID string        `json:"last_backup_snapshot_id,omitempty"`
+	LastBackupTime       string        `json:"last_backup_time,omitempty"`
+	LastBackupStatus     string        `json:"last_backup_status,omitempty"`
+	NextBackupTime       string        `json:"next_backup_time,omitempty"`
+	CreatedAt            string        `json:"created_at"`
+	UpdatedAt            string        `json:"updated_at"`
+	TargetAccount        string        `json:"target_account,omitempty"`
+	TargetRegion         string        `json:"target_region,omitempty"`
+	AutoCreatePR         bool          `json:"auto_create_pr"`
+	ResilienceEnabled    bool          `json:"resilience_enabled"`
 }
 
 // ScopeConfig represents a resource scope configuration
@@ -89,7 +88,6 @@ type ScopeConfig struct {
 
 // VCSConfig represents VCS integration configuration
 type VCSConfig struct {
-	ProjectID        string `json:"project_id,omitempty"`
 	VCSIntegrationID string `json:"vcs_integration_id,omitempty"`
 	RepoID           string `json:"repo_id,omitempty"`
 }
@@ -144,8 +142,15 @@ func ConvertCreateToUpdate(create *PolicyCreateRequest) *PolicyUpdateRequest {
 		IntegrationID:       &create.IntegrationID,
 		Region:              &create.Region,
 		ProviderType:        &create.ProviderType,
-		Schedule:            &create.Schedule,
 		RestoreInstructions: &create.RestoreInstructions,
+		BackupOnSave:        &create.BackupOnSave,
+		AutoCreatePR:        &create.AutoCreatePR,
+		ResilienceEnabled:   &create.ResilienceEnabled,
+	}
+
+	if create.Frequency != 0 {
+		freq := create.Frequency
+		update.Frequency = &freq
 	}
 
 	if create.Description != "" {
@@ -164,14 +169,20 @@ func ConvertCreateToUpdate(create *PolicyCreateRequest) *PolicyUpdateRequest {
 		update.VCS = create.VCS
 	}
 
-	update.BackupOnSave = &create.BackupOnSave
+	if create.TargetAccount != "" {
+		update.TargetAccount = &create.TargetAccount
+	}
+
+	if create.TargetRegion != "" {
+		update.TargetRegion = &create.TargetRegion
+	}
 
 	return update
 }
 
 // Create creates a new backup policy
-func (s *BackupAndDrService) Create(policy *PolicyCreateRequest) (*PolicyResponse, error) {
-	endpoint := "/v2/backup-and-dr/policies"
+func (s *BackupAndDrService) Create(accountID string, policy *PolicyCreateRequest) (*PolicyResponse, error) {
+	endpoint := fmt.Sprintf("/backup/%s/policies", url.PathEscape(accountID))
 
 	req, err := s.client.newRequest("POST", endpoint, policy)
 	if err != nil {
@@ -198,8 +209,8 @@ func (s *BackupAndDrService) Create(policy *PolicyCreateRequest) (*PolicyRespons
 }
 
 // Get retrieves a specific backup policy by ID
-func (s *BackupAndDrService) Get(policyID string) (*PolicyResponse, error) {
-	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
+func (s *BackupAndDrService) Get(accountID, policyID string) (*PolicyResponse, error) {
+	endpoint := fmt.Sprintf("/backup/%s/policies/%s", url.PathEscape(accountID), url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("GET", endpoint, nil)
 	if err != nil {
@@ -230,8 +241,8 @@ func (s *BackupAndDrService) Get(policyID string) (*PolicyResponse, error) {
 }
 
 // Update updates an existing backup policy
-func (s *BackupAndDrService) Update(policyID string, policy *PolicyUpdateRequest) (*PolicyResponse, error) {
-	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
+func (s *BackupAndDrService) Update(accountID, policyID string, policy *PolicyUpdateRequest) (*PolicyResponse, error) {
+	endpoint := fmt.Sprintf("/backup/%s/policies/%s", url.PathEscape(accountID), url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("PUT", endpoint, policy)
 	if err != nil {
@@ -258,8 +269,8 @@ func (s *BackupAndDrService) Update(policyID string, policy *PolicyUpdateRequest
 }
 
 // Delete deletes a backup policy
-func (s *BackupAndDrService) Delete(policyID string) error {
-	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
+func (s *BackupAndDrService) Delete(accountID, policyID string) error {
+	endpoint := fmt.Sprintf("/backup/%s/policies/%s", url.PathEscape(accountID), url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("DELETE", endpoint, nil)
 	if err != nil {
@@ -282,8 +293,8 @@ func (s *BackupAndDrService) Delete(policyID string) error {
 }
 
 // List retrieves all backup policies with optional filters
-func (s *BackupAndDrService) List(filters *PolicyListFilters) (*PolicyListResponse, error) {
-	endpoint := "/v2/backup-and-dr/policies"
+func (s *BackupAndDrService) List(accountID string, filters *PolicyListFilters) (*PolicyListResponse, error) {
+	endpoint := fmt.Sprintf("/backup/%s/policies", url.PathEscape(accountID))
 
 	// Build query parameters if filters are provided
 	queryParams := url.Values{}

--- a/internal/client/backup_and_dr.go
+++ b/internal/client/backup_and_dr.go
@@ -181,7 +181,7 @@ func ConvertCreateToUpdate(create *PolicyCreateRequest) *PolicyUpdateRequest {
 }
 
 // Create creates a new backup policy
-func (s *BackupAndDrService) Create(accountID string, policy *PolicyCreateRequest) (*PolicyResponse, error) {
+func (s *BackupAndDrService) Create(policy *PolicyCreateRequest) (*PolicyResponse, error) {
 	endpoint := "/v2/backup-and-dr/policies"
 
 	req, err := s.client.newRequest("POST", endpoint, policy)
@@ -209,7 +209,7 @@ func (s *BackupAndDrService) Create(accountID string, policy *PolicyCreateReques
 }
 
 // Get retrieves a specific backup policy by ID
-func (s *BackupAndDrService) Get(accountID, policyID string) (*PolicyResponse, error) {
+func (s *BackupAndDrService) Get(policyID string) (*PolicyResponse, error) {
 	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("GET", endpoint, nil)
@@ -241,7 +241,7 @@ func (s *BackupAndDrService) Get(accountID, policyID string) (*PolicyResponse, e
 }
 
 // Update updates an existing backup policy
-func (s *BackupAndDrService) Update(accountID, policyID string, policy *PolicyUpdateRequest) (*PolicyResponse, error) {
+func (s *BackupAndDrService) Update(policyID string, policy *PolicyUpdateRequest) (*PolicyResponse, error) {
 	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("PUT", endpoint, policy)
@@ -269,7 +269,7 @@ func (s *BackupAndDrService) Update(accountID, policyID string, policy *PolicyUp
 }
 
 // Delete deletes a backup policy
-func (s *BackupAndDrService) Delete(accountID, policyID string) error {
+func (s *BackupAndDrService) Delete(policyID string) error {
 	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("DELETE", endpoint, nil)
@@ -293,7 +293,7 @@ func (s *BackupAndDrService) Delete(accountID, policyID string) error {
 }
 
 // List retrieves all backup policies with optional filters
-func (s *BackupAndDrService) List(accountID string, filters *PolicyListFilters) (*PolicyListResponse, error) {
+func (s *BackupAndDrService) List(filters *PolicyListFilters) (*PolicyListResponse, error) {
 	endpoint := "/v2/backup-and-dr/policies"
 
 	// Build query parameters if filters are provided

--- a/internal/client/backup_and_dr.go
+++ b/internal/client/backup_and_dr.go
@@ -182,7 +182,7 @@ func ConvertCreateToUpdate(create *PolicyCreateRequest) *PolicyUpdateRequest {
 
 // Create creates a new backup policy
 func (s *BackupAndDrService) Create(accountID string, policy *PolicyCreateRequest) (*PolicyResponse, error) {
-	endpoint := fmt.Sprintf("/backup/%s/policies", url.PathEscape(accountID))
+	endpoint := "/v2/backup-and-dr/policies"
 
 	req, err := s.client.newRequest("POST", endpoint, policy)
 	if err != nil {
@@ -210,7 +210,7 @@ func (s *BackupAndDrService) Create(accountID string, policy *PolicyCreateReques
 
 // Get retrieves a specific backup policy by ID
 func (s *BackupAndDrService) Get(accountID, policyID string) (*PolicyResponse, error) {
-	endpoint := fmt.Sprintf("/backup/%s/policies/%s", url.PathEscape(accountID), url.PathEscape(policyID))
+	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("GET", endpoint, nil)
 	if err != nil {
@@ -242,7 +242,7 @@ func (s *BackupAndDrService) Get(accountID, policyID string) (*PolicyResponse, e
 
 // Update updates an existing backup policy
 func (s *BackupAndDrService) Update(accountID, policyID string, policy *PolicyUpdateRequest) (*PolicyResponse, error) {
-	endpoint := fmt.Sprintf("/backup/%s/policies/%s", url.PathEscape(accountID), url.PathEscape(policyID))
+	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("PUT", endpoint, policy)
 	if err != nil {
@@ -270,7 +270,7 @@ func (s *BackupAndDrService) Update(accountID, policyID string, policy *PolicyUp
 
 // Delete deletes a backup policy
 func (s *BackupAndDrService) Delete(accountID, policyID string) error {
-	endpoint := fmt.Sprintf("/backup/%s/policies/%s", url.PathEscape(accountID), url.PathEscape(policyID))
+	endpoint := fmt.Sprintf("/v2/backup-and-dr/policies/%s", url.PathEscape(policyID))
 
 	req, err := s.client.newRequest("DELETE", endpoint, nil)
 	if err != nil {
@@ -294,7 +294,7 @@ func (s *BackupAndDrService) Delete(accountID, policyID string) error {
 
 // List retrieves all backup policies with optional filters
 func (s *BackupAndDrService) List(accountID string, filters *PolicyListFilters) (*PolicyListResponse, error) {
-	endpoint := fmt.Sprintf("/backup/%s/policies", url.PathEscape(accountID))
+	endpoint := "/v2/backup-and-dr/policies"
 
 	// Build query parameters if filters are provided
 	queryParams := url.Values{}

--- a/internal/client/backup_and_dr_test.go
+++ b/internal/client/backup_and_dr_test.go
@@ -18,7 +18,7 @@ func TestBackupAndDrService_Create(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -108,7 +108,7 @@ func TestBackupAndDrService_CreateWithScope(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
 		var createReq PolicyCreateRequest
 		json.NewDecoder(r.Body).Decode(&createReq)
 
@@ -186,7 +186,7 @@ func TestBackupAndDrService_CreateWithVCS(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
 		var createReq PolicyCreateRequest
 		json.NewDecoder(r.Body).Decode(&createReq)
 
@@ -258,7 +258,7 @@ func TestBackupAndDrService_CreateWithResilienceFields(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
 		var createReq PolicyCreateRequest
 		json.NewDecoder(r.Body).Decode(&createReq)
 
@@ -337,13 +337,13 @@ func TestBackupAndDrService_Get(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies/", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
-		policyID := r.URL.Path[len("/backup/test-account/policies/"):]
+		policyID := r.URL.Path[len("/v2/backup-and-dr/policies/"):]
 		if policyID != "policy-123" {
 			http.Error(w, "Not found", http.StatusNotFound)
 			return
@@ -403,13 +403,13 @@ func TestBackupAndDrService_Update(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies/", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
-		policyID := r.URL.Path[len("/backup/test-account/policies/"):]
+		policyID := r.URL.Path[len("/v2/backup-and-dr/policies/"):]
 		if policyID != "policy-123" {
 			http.Error(w, "Not found", http.StatusNotFound)
 			return
@@ -492,13 +492,13 @@ func TestBackupAndDrService_Delete(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies/", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
-		policyID := r.URL.Path[len("/backup/test-account/policies/"):]
+		policyID := r.URL.Path[len("/v2/backup-and-dr/policies/"):]
 		if policyID != "policy-123" {
 			http.Error(w, "Not found", http.StatusNotFound)
 			return
@@ -531,7 +531,7 @@ func TestBackupAndDrService_List(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -611,7 +611,7 @@ func TestBackupAndDrService_ListWithFilters(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
 		status := r.URL.Query().Get("status")
 		region := r.URL.Query().Get("region")
 
@@ -688,7 +688,7 @@ func TestBackupAndDrService_ErrorHandling(t *testing.T) {
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	mockServer.AddHandler("/backup/test-account/policies/not-found", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/v2/backup-and-dr/policies/not-found", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Policy not found", http.StatusNotFound)
 	})
 

--- a/internal/client/backup_and_dr_test.go
+++ b/internal/client/backup_and_dr_test.go
@@ -7,18 +7,18 @@ import (
 	"time"
 )
 
+const testAccountID = "test-account"
+
 func TestBackupAndDrService_Create(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock create policy
-	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -30,21 +30,19 @@ func TestBackupAndDrService_Create(t *testing.T) {
 			return
 		}
 
-		// Validate required fields
 		if createReq.PolicyName == "" {
 			http.Error(w, "PolicyName is required", http.StatusBadRequest)
 			return
 		}
 
-		// Create response
 		createResp := PolicyResponse{
 			PolicyID:        "policy-123",
-			AccountID:       "test-account",
+			AccountID:       testAccountID,
 			PolicyName:      createReq.PolicyName,
 			IntegrationID:   createReq.IntegrationID,
 			Region:          createReq.Region,
 			ProviderType:    createReq.ProviderType,
-			Schedule:        createReq.Schedule,
+			Frequency:       createReq.Frequency,
 			Description:     createReq.Description,
 			Scope:           createReq.Scope,
 			NotificationID:  createReq.NotificationID,
@@ -60,12 +58,11 @@ func TestBackupAndDrService_Create(t *testing.T) {
 		json.NewEncoder(w).Encode(createResp)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -75,16 +72,12 @@ func TestBackupAndDrService_Create(t *testing.T) {
 		IntegrationID: "int-123",
 		Region:        "us-east-1",
 		ProviderType:  "aws",
-		Schedule: ScheduleConfig{
-			Frequency: "Daily",
-			Hour:      2,
-			Minute:    30,
-		},
-		Description:  "Test backup policy",
-		BackupOnSave: true,
+		Frequency:     24,
+		Description:   "Test backup policy",
+		BackupOnSave:  true,
 	}
 
-	response, err := client.BackupAndDr.Create(policy)
+	response, err := c.BackupAndDr.Create(testAccountID, policy)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -101,152 +94,8 @@ func TestBackupAndDrService_Create(t *testing.T) {
 		t.Errorf("Expected status 'Active', got '%s'", response.Status)
 	}
 
-	if response.Schedule.Frequency != "Daily" {
-		t.Errorf("Expected frequency 'Daily', got '%s'", response.Schedule.Frequency)
-	}
-}
-
-func TestBackupAndDrService_CreateWithWeeklySchedule(t *testing.T) {
-	mockServer := NewMockServer()
-	defer mockServer.Close()
-
-	// Mock login
-	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
-		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
-		json.NewEncoder(w).Encode(authResp)
-	})
-
-	// Mock create policy
-	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
-		var createReq PolicyCreateRequest
-		json.NewDecoder(r.Body).Decode(&createReq)
-
-		createResp := PolicyResponse{
-			PolicyID:       "policy-456",
-			AccountID:      "test-account",
-			PolicyName:     createReq.PolicyName,
-			IntegrationID:  createReq.IntegrationID,
-			Region:         createReq.Region,
-			ProviderType:   createReq.ProviderType,
-			Schedule:       createReq.Schedule,
-			Status:         "Active",
-			SnapshotsCount: 0,
-			CreatedAt:      "2025-01-01T00:00:00Z",
-			UpdatedAt:      "2025-01-01T00:00:00Z",
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(createResp)
-	})
-
-	client, err := NewClient(Config{
-		AccessKey: "test-access",
-		SecretKey: "test-secret",
-		APIURL:    mockServer.URL(),
-	})
-
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	policy := &PolicyCreateRequest{
-		PolicyName:    "Test Weekly Backup",
-		IntegrationID: "int-123",
-		Region:        "us-west-2",
-		ProviderType:  "aws",
-		Schedule: ScheduleConfig{
-			Frequency:  "Weekly",
-			DaysOfWeek: []string{"Sunday", "Wednesday"},
-			Hour:       1,
-			Minute:     0,
-		},
-		BackupOnSave: true,
-	}
-
-	response, err := client.BackupAndDr.Create(policy)
-	if err != nil {
-		t.Fatalf("Create failed: %v", err)
-	}
-
-	if len(response.Schedule.DaysOfWeek) != 2 {
-		t.Errorf("Expected 2 days of week, got %d", len(response.Schedule.DaysOfWeek))
-	}
-
-	if response.Schedule.DaysOfWeek[0] != "Sunday" {
-		t.Errorf("Expected first day 'Sunday', got '%s'", response.Schedule.DaysOfWeek[0])
-	}
-}
-
-func TestBackupAndDrService_CreateWithMonthlySchedule(t *testing.T) {
-	mockServer := NewMockServer()
-	defer mockServer.Close()
-
-	// Mock login
-	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
-		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
-		json.NewEncoder(w).Encode(authResp)
-	})
-
-	// Mock create policy
-	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
-		var createReq PolicyCreateRequest
-		json.NewDecoder(r.Body).Decode(&createReq)
-
-		createResp := PolicyResponse{
-			PolicyID:       "policy-789",
-			AccountID:      "test-account",
-			PolicyName:     createReq.PolicyName,
-			IntegrationID:  createReq.IntegrationID,
-			Region:         createReq.Region,
-			ProviderType:   createReq.ProviderType,
-			Schedule:       createReq.Schedule,
-			Status:         "Active",
-			SnapshotsCount: 0,
-			CreatedAt:      "2025-01-01T00:00:00Z",
-			UpdatedAt:      "2025-01-01T00:00:00Z",
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(createResp)
-	})
-
-	client, err := NewClient(Config{
-		AccessKey: "test-access",
-		SecretKey: "test-secret",
-		APIURL:    mockServer.URL(),
-	})
-
-	if err != nil {
-		t.Fatalf("Failed to create client: %v", err)
-	}
-
-	policy := &PolicyCreateRequest{
-		PolicyName:    "Test Monthly Backup",
-		IntegrationID: "int-123",
-		Region:        "us-east-1",
-		ProviderType:  "aws",
-		Schedule: ScheduleConfig{
-			Frequency:           "Monthly",
-			MonthlyScheduleType: "specific_weekday",
-			WeekdayOrdinal:      "First",
-			WeekdayName:         "Sunday",
-			Hour:                3,
-			Minute:              0,
-		},
-		BackupOnSave: true,
-	}
-
-	response, err := client.BackupAndDr.Create(policy)
-	if err != nil {
-		t.Fatalf("Create failed: %v", err)
-	}
-
-	if response.Schedule.MonthlyScheduleType != "specific_weekday" {
-		t.Errorf("Expected monthly_schedule_type 'specific_weekday', got '%s'", response.Schedule.MonthlyScheduleType)
-	}
-
-	if response.Schedule.WeekdayOrdinal != "First" {
-		t.Errorf("Expected weekday_ordinal 'First', got '%s'", response.Schedule.WeekdayOrdinal)
+	if response.Frequency != 24 {
+		t.Errorf("Expected frequency 24, got %d", response.Frequency)
 	}
 }
 
@@ -254,25 +103,23 @@ func TestBackupAndDrService_CreateWithScope(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock create policy
-	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
 		var createReq PolicyCreateRequest
 		json.NewDecoder(r.Body).Decode(&createReq)
 
 		createResp := PolicyResponse{
 			PolicyID:       "policy-scope",
-			AccountID:      "test-account",
+			AccountID:      testAccountID,
 			PolicyName:     createReq.PolicyName,
 			IntegrationID:  createReq.IntegrationID,
 			Region:         createReq.Region,
 			ProviderType:   createReq.ProviderType,
-			Schedule:       createReq.Schedule,
+			Frequency:      createReq.Frequency,
 			Scope:          createReq.Scope,
 			Status:         "Active",
 			SnapshotsCount: 0,
@@ -284,12 +131,11 @@ func TestBackupAndDrService_CreateWithScope(t *testing.T) {
 		json.NewEncoder(w).Encode(createResp)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -299,11 +145,7 @@ func TestBackupAndDrService_CreateWithScope(t *testing.T) {
 		IntegrationID: "int-123",
 		Region:        "us-east-1",
 		ProviderType:  "aws",
-		Schedule: ScheduleConfig{
-			Frequency: "Daily",
-			Hour:      2,
-			Minute:    0,
-		},
+		Frequency:     8,
 		Scope: []ScopeConfig{
 			{
 				Type:  "tags",
@@ -317,7 +159,7 @@ func TestBackupAndDrService_CreateWithScope(t *testing.T) {
 		BackupOnSave: true,
 	}
 
-	response, err := client.BackupAndDr.Create(policy)
+	response, err := c.BackupAndDr.Create(testAccountID, policy)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -339,25 +181,23 @@ func TestBackupAndDrService_CreateWithVCS(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock create policy
-	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
 		var createReq PolicyCreateRequest
 		json.NewDecoder(r.Body).Decode(&createReq)
 
 		createResp := PolicyResponse{
 			PolicyID:       "policy-vcs",
-			AccountID:      "test-account",
+			AccountID:      testAccountID,
 			PolicyName:     createReq.PolicyName,
 			IntegrationID:  createReq.IntegrationID,
 			Region:         createReq.Region,
 			ProviderType:   createReq.ProviderType,
-			Schedule:       createReq.Schedule,
+			Frequency:      createReq.Frequency,
 			VCS:            createReq.VCS,
 			Status:         "Active",
 			SnapshotsCount: 0,
@@ -369,12 +209,11 @@ func TestBackupAndDrService_CreateWithVCS(t *testing.T) {
 		json.NewEncoder(w).Encode(createResp)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -384,20 +223,15 @@ func TestBackupAndDrService_CreateWithVCS(t *testing.T) {
 		IntegrationID: "int-123",
 		Region:        "us-east-1",
 		ProviderType:  "aws",
-		Schedule: ScheduleConfig{
-			Frequency: "Daily",
-			Hour:      2,
-			Minute:    0,
-		},
+		Frequency:     24,
 		VCS: &VCSConfig{
-			ProjectID:        "project-456",
 			VCSIntegrationID: "github-integration-789",
 			RepoID:           "backup-repo-123",
 		},
 		BackupOnSave: true,
 	}
 
-	response, err := client.BackupAndDr.Create(policy)
+	response, err := c.BackupAndDr.Create(testAccountID, policy)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -406,12 +240,91 @@ func TestBackupAndDrService_CreateWithVCS(t *testing.T) {
 		t.Fatal("Expected VCS config, got nil")
 	}
 
-	if response.VCS.ProjectID != "project-456" {
-		t.Errorf("Expected VCS project ID 'project-456', got '%s'", response.VCS.ProjectID)
-	}
-
 	if response.VCS.VCSIntegrationID != "github-integration-789" {
 		t.Errorf("Expected VCS integration ID 'github-integration-789', got '%s'", response.VCS.VCSIntegrationID)
+	}
+
+	if response.VCS.RepoID != "backup-repo-123" {
+		t.Errorf("Expected VCS repo ID 'backup-repo-123', got '%s'", response.VCS.RepoID)
+	}
+}
+
+func TestBackupAndDrService_CreateWithResilienceFields(t *testing.T) {
+	mockServer := NewMockServer()
+	defer mockServer.Close()
+
+	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
+		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
+		json.NewEncoder(w).Encode(authResp)
+	})
+
+	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
+		var createReq PolicyCreateRequest
+		json.NewDecoder(r.Body).Decode(&createReq)
+
+		createResp := PolicyResponse{
+			PolicyID:          "policy-resilience",
+			AccountID:         testAccountID,
+			PolicyName:        createReq.PolicyName,
+			IntegrationID:     createReq.IntegrationID,
+			Region:            createReq.Region,
+			ProviderType:      createReq.ProviderType,
+			Frequency:         createReq.Frequency,
+			TargetAccount:     createReq.TargetAccount,
+			TargetRegion:      createReq.TargetRegion,
+			AutoCreatePR:      createReq.AutoCreatePR,
+			ResilienceEnabled: createReq.ResilienceEnabled,
+			Status:            "Active",
+			SnapshotsCount:    0,
+			CreatedAt:         "2025-01-01T00:00:00Z",
+			UpdatedAt:         "2025-01-01T00:00:00Z",
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(createResp)
+	})
+
+	c, err := NewClient(Config{
+		AccessKey: "test-access",
+		SecretKey: "test-secret",
+		APIURL:    mockServer.URL(),
+	})
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	policy := &PolicyCreateRequest{
+		PolicyName:        "Test Resilience Backup",
+		IntegrationID:     "int-123",
+		Region:            "us-east-1",
+		ProviderType:      "aws",
+		Frequency:         4,
+		TargetAccount:     "target-int-456",
+		TargetRegion:      "eu-west-1",
+		AutoCreatePR:      true,
+		ResilienceEnabled: true,
+	}
+
+	response, err := c.BackupAndDr.Create(testAccountID, policy)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if response.TargetAccount != "target-int-456" {
+		t.Errorf("Expected TargetAccount 'target-int-456', got '%s'", response.TargetAccount)
+	}
+
+	if response.TargetRegion != "eu-west-1" {
+		t.Errorf("Expected TargetRegion 'eu-west-1', got '%s'", response.TargetRegion)
+	}
+
+	if !response.AutoCreatePR {
+		t.Error("Expected AutoCreatePR true, got false")
+	}
+
+	if !response.ResilienceEnabled {
+		t.Error("Expected ResilienceEnabled true, got false")
 	}
 }
 
@@ -419,37 +332,31 @@ func TestBackupAndDrService_Get(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock get policy
-	mockServer.AddHandler("/v2/backup-and-dr/policies/", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/backup/test-account/policies/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
-		policyID := r.URL.Path[len("/v2/backup-and-dr/policies/"):]
+		policyID := r.URL.Path[len("/backup/test-account/policies/"):]
 		if policyID != "policy-123" {
 			http.Error(w, "Not found", http.StatusNotFound)
 			return
 		}
 
 		policy := PolicyResponse{
-			PolicyID:      "policy-123",
-			AccountID:     "test-account",
-			PolicyName:    "Test Policy",
-			IntegrationID: "int-123",
-			Region:        "us-east-1",
-			ProviderType:  "aws",
-			Schedule: ScheduleConfig{
-				Frequency: "Daily",
-				Hour:      2,
-				Minute:    30,
-			},
+			PolicyID:       "policy-123",
+			AccountID:      testAccountID,
+			PolicyName:     "Test Policy",
+			IntegrationID:  "int-123",
+			Region:         "us-east-1",
+			ProviderType:   "aws",
+			Frequency:      24,
 			Status:         "Active",
 			SnapshotsCount: 5,
 			CreatedAt:      "2025-01-01T00:00:00Z",
@@ -460,17 +367,16 @@ func TestBackupAndDrService_Get(t *testing.T) {
 		json.NewEncoder(w).Encode(policy)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	response, err := client.BackupAndDr.Get("policy-123")
+	response, err := c.BackupAndDr.Get(testAccountID, "policy-123")
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
@@ -492,53 +398,58 @@ func TestBackupAndDrService_Update(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock update policy
-	mockServer.AddHandler("/v2/backup-and-dr/policies/", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/backup/test-account/policies/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
-		policyID := r.URL.Path[len("/v2/backup-and-dr/policies/"):]
+		policyID := r.URL.Path[len("/backup/test-account/policies/"):]
 		if policyID != "policy-123" {
 			http.Error(w, "Not found", http.StatusNotFound)
 			return
 		}
 
-		var updateReq PolicyCreateRequest
+		var updateReq PolicyUpdateRequest
 		json.NewDecoder(r.Body).Decode(&updateReq)
+
+		freq := 0
+		if updateReq.Frequency != nil {
+			freq = *updateReq.Frequency
+		}
 
 		updateResp := PolicyResponse{
 			PolicyID:       policyID,
-			AccountID:      "test-account",
-			PolicyName:     updateReq.PolicyName,
-			IntegrationID:  updateReq.IntegrationID,
-			Region:         updateReq.Region,
-			ProviderType:   updateReq.ProviderType,
-			Schedule:       updateReq.Schedule,
-			Description:    updateReq.Description,
+			AccountID:      testAccountID,
+			PolicyName:     *updateReq.PolicyName,
+			IntegrationID:  *updateReq.IntegrationID,
+			Region:         *updateReq.Region,
+			ProviderType:   *updateReq.ProviderType,
+			Frequency:      freq,
 			Status:         "Active",
 			SnapshotsCount: 10,
 			CreatedAt:      "2025-01-01T00:00:00Z",
 			UpdatedAt:      "2025-01-02T00:00:00Z",
 		}
 
+		if updateReq.Description != nil {
+			updateResp.Description = *updateReq.Description
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(updateResp)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -548,18 +459,13 @@ func TestBackupAndDrService_Update(t *testing.T) {
 		IntegrationID: "int-123",
 		Region:        "us-east-1",
 		ProviderType:  "aws",
-		Schedule: ScheduleConfig{
-			Frequency:  "Weekly",
-			DaysOfWeek: []string{"Monday", "Friday"},
-			Hour:       3,
-			Minute:     0,
-		},
-		Description:  "Updated description",
-		BackupOnSave: true,
+		Frequency:     8,
+		Description:   "Updated description",
+		BackupOnSave:  true,
 	}
 
 	updatePolicy := ConvertCreateToUpdate(policy)
-	response, err := client.BackupAndDr.Update("policy-123", updatePolicy)
+	response, err := c.BackupAndDr.Update(testAccountID, "policy-123", updatePolicy)
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
@@ -568,8 +474,8 @@ func TestBackupAndDrService_Update(t *testing.T) {
 		t.Errorf("Expected name 'Updated Policy', got '%s'", response.PolicyName)
 	}
 
-	if response.Schedule.Frequency != "Weekly" {
-		t.Errorf("Expected frequency 'Weekly', got '%s'", response.Schedule.Frequency)
+	if response.Frequency != 8 {
+		t.Errorf("Expected frequency 8, got %d", response.Frequency)
 	}
 
 	if response.Description != "Updated description" {
@@ -581,20 +487,18 @@ func TestBackupAndDrService_Delete(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock delete policy
-	mockServer.AddHandler("/v2/backup-and-dr/policies/", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/backup/test-account/policies/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
 
-		policyID := r.URL.Path[len("/v2/backup-and-dr/policies/"):]
+		policyID := r.URL.Path[len("/backup/test-account/policies/"):]
 		if policyID != "policy-123" {
 			http.Error(w, "Not found", http.StatusNotFound)
 			return
@@ -603,17 +507,16 @@ func TestBackupAndDrService_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = client.BackupAndDr.Delete("policy-123")
+	err = c.BackupAndDr.Delete(testAccountID, "policy-123")
 	if err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
@@ -623,14 +526,12 @@ func TestBackupAndDrService_List(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock list policies
-	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -639,33 +540,24 @@ func TestBackupAndDrService_List(t *testing.T) {
 		response := PolicyListResponse{
 			Data: []PolicyResponse{
 				{
-					PolicyID:      "policy-1",
-					AccountID:     "test-account",
-					PolicyName:    "Daily Backup",
-					IntegrationID: "int-123",
-					Region:        "us-east-1",
-					ProviderType:  "aws",
-					Schedule: ScheduleConfig{
-						Frequency: "Daily",
-						Hour:      2,
-						Minute:    0,
-					},
+					PolicyID:       "policy-1",
+					AccountID:      testAccountID,
+					PolicyName:     "Daily Backup",
+					IntegrationID:  "int-123",
+					Region:         "us-east-1",
+					ProviderType:   "aws",
+					Frequency:      24,
 					Status:         "Active",
 					SnapshotsCount: 5,
 				},
 				{
-					PolicyID:      "policy-2",
-					AccountID:     "test-account",
-					PolicyName:    "Weekly Backup",
-					IntegrationID: "int-456",
-					Region:        "us-west-2",
-					ProviderType:  "aws",
-					Schedule: ScheduleConfig{
-						Frequency:  "Weekly",
-						DaysOfWeek: []string{"Sunday"},
-						Hour:       1,
-						Minute:     0,
-					},
+					PolicyID:       "policy-2",
+					AccountID:      testAccountID,
+					PolicyName:     "Frequent Backup",
+					IntegrationID:  "int-456",
+					Region:         "us-west-2",
+					ProviderType:   "aws",
+					Frequency:      4,
 					Status:         "Inactive",
 					SnapshotsCount: 0,
 				},
@@ -683,17 +575,16 @@ func TestBackupAndDrService_List(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	response, err := client.BackupAndDr.List(nil)
+	response, err := c.BackupAndDr.List(testAccountID, nil)
 	if err != nil {
 		t.Fatalf("List failed: %v", err)
 	}
@@ -715,15 +606,12 @@ func TestBackupAndDrService_ListWithFilters(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock list policies with query parameters
-	mockServer.AddHandler("/v2/backup-and-dr/policies", func(w http.ResponseWriter, r *http.Request) {
-		// Verify query parameters
+	mockServer.AddHandler("/backup/test-account/policies", func(w http.ResponseWriter, r *http.Request) {
 		status := r.URL.Query().Get("status")
 		region := r.URL.Query().Get("region")
 
@@ -735,17 +623,13 @@ func TestBackupAndDrService_ListWithFilters(t *testing.T) {
 		response := PolicyListResponse{
 			Data: []PolicyResponse{
 				{
-					PolicyID:      "policy-filtered",
-					AccountID:     "test-account",
-					PolicyName:    "Filtered Policy",
-					IntegrationID: "int-123",
-					Region:        "us-east-1",
-					ProviderType:  "aws",
-					Schedule: ScheduleConfig{
-						Frequency: "Daily",
-						Hour:      2,
-						Minute:    0,
-					},
+					PolicyID:       "policy-filtered",
+					AccountID:      testAccountID,
+					PolicyName:     "Filtered Policy",
+					IntegrationID:  "int-123",
+					Region:         "us-east-1",
+					ProviderType:   "aws",
+					Frequency:      24,
 					Status:         "Active",
 					SnapshotsCount: 3,
 				},
@@ -763,12 +647,11 @@ func TestBackupAndDrService_ListWithFilters(t *testing.T) {
 		json.NewEncoder(w).Encode(response)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
@@ -778,7 +661,7 @@ func TestBackupAndDrService_ListWithFilters(t *testing.T) {
 		Region: "us-east-1",
 	}
 
-	response, err := client.BackupAndDr.List(filters)
+	response, err := c.BackupAndDr.List(testAccountID, filters)
 	if err != nil {
 		t.Fatalf("List with filters failed: %v", err)
 	}
@@ -800,35 +683,30 @@ func TestBackupAndDrService_ErrorHandling(t *testing.T) {
 	mockServer := NewMockServer()
 	defer mockServer.Close()
 
-	// Mock login
 	mockServer.AddHandler("/v2/login", func(w http.ResponseWriter, r *http.Request) {
 		authResp := AuthResponse{AccessToken: "test-token", ExpiresAt: time.Now().Add(time.Hour).Unix()}
 		json.NewEncoder(w).Encode(authResp)
 	})
 
-	// Mock error responses
-	mockServer.AddHandler("/v2/backup-and-dr/policies/not-found", func(w http.ResponseWriter, r *http.Request) {
+	mockServer.AddHandler("/backup/test-account/policies/not-found", func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Policy not found", http.StatusNotFound)
 	})
 
-	client, err := NewClient(Config{
+	c, err := NewClient(Config{
 		AccessKey: "test-access",
 		SecretKey: "test-secret",
 		APIURL:    mockServer.URL(),
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	// Test Get with not found
-	_, err = client.BackupAndDr.Get("not-found")
+	_, err = c.BackupAndDr.Get(testAccountID, "not-found")
 	if err == nil {
 		t.Error("Expected error for not found policy, got nil")
 	}
 
-	// Test Delete with not found
-	err = client.BackupAndDr.Delete("not-found")
+	err = c.BackupAndDr.Delete(testAccountID, "not-found")
 	if err == nil {
 		t.Error("Expected error for deleting not found policy, got nil")
 	}

--- a/internal/client/backup_and_dr_test.go
+++ b/internal/client/backup_and_dr_test.go
@@ -77,7 +77,7 @@ func TestBackupAndDrService_Create(t *testing.T) {
 		BackupOnSave:  true,
 	}
 
-	response, err := c.BackupAndDr.Create(testAccountID, policy)
+	response, err := c.BackupAndDr.Create(policy)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestBackupAndDrService_CreateWithScope(t *testing.T) {
 		BackupOnSave: true,
 	}
 
-	response, err := c.BackupAndDr.Create(testAccountID, policy)
+	response, err := c.BackupAndDr.Create(policy)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestBackupAndDrService_CreateWithVCS(t *testing.T) {
 		BackupOnSave: true,
 	}
 
-	response, err := c.BackupAndDr.Create(testAccountID, policy)
+	response, err := c.BackupAndDr.Create(policy)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestBackupAndDrService_CreateWithResilienceFields(t *testing.T) {
 		ResilienceEnabled: true,
 	}
 
-	response, err := c.BackupAndDr.Create(testAccountID, policy)
+	response, err := c.BackupAndDr.Create(policy)
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestBackupAndDrService_Get(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	response, err := c.BackupAndDr.Get(testAccountID, "policy-123")
+	response, err := c.BackupAndDr.Get("policy-123")
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestBackupAndDrService_Update(t *testing.T) {
 	}
 
 	updatePolicy := ConvertCreateToUpdate(policy)
-	response, err := c.BackupAndDr.Update(testAccountID, "policy-123", updatePolicy)
+	response, err := c.BackupAndDr.Update("policy-123", updatePolicy)
 	if err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestBackupAndDrService_Delete(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = c.BackupAndDr.Delete(testAccountID, "policy-123")
+	err = c.BackupAndDr.Delete("policy-123")
 	if err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
@@ -584,7 +584,7 @@ func TestBackupAndDrService_List(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	response, err := c.BackupAndDr.List(testAccountID, nil)
+	response, err := c.BackupAndDr.List(nil)
 	if err != nil {
 		t.Fatalf("List failed: %v", err)
 	}
@@ -661,7 +661,7 @@ func TestBackupAndDrService_ListWithFilters(t *testing.T) {
 		Region: "us-east-1",
 	}
 
-	response, err := c.BackupAndDr.List(testAccountID, filters)
+	response, err := c.BackupAndDr.List(filters)
 	if err != nil {
 		t.Fatalf("List with filters failed: %v", err)
 	}
@@ -701,12 +701,12 @@ func TestBackupAndDrService_ErrorHandling(t *testing.T) {
 		t.Fatalf("Failed to create client: %v", err)
 	}
 
-	_, err = c.BackupAndDr.Get(testAccountID, "not-found")
+	_, err = c.BackupAndDr.Get("not-found")
 	if err == nil {
 		t.Error("Expected error for not found policy, got nil")
 	}
 
-	err = c.BackupAndDr.Delete(testAccountID, "not-found")
+	err = c.BackupAndDr.Delete("not-found")
 	if err == nil {
 		t.Error("Expected error for deleting not found policy, got nil")
 	}

--- a/internal/provider/data_source_backup_and_dr_applications.go
+++ b/internal/provider/data_source_backup_and_dr_applications.go
@@ -91,8 +91,8 @@ func (d *BackupAndDrApplicationsDataSource) Schema(ctx context.Context, req data
 							MarkdownDescription: "Description of the backup application",
 							Computed:            true,
 						},
-						"schedule_frequency": schema.StringAttribute{
-							MarkdownDescription: "Backup schedule frequency (One-time, Daily, Weekly, Monthly)",
+						"frequency": schema.Int64Attribute{
+							MarkdownDescription: "Hours between scheduled backups (4, 8, 16, or 24)",
 							Computed:            true,
 						},
 						"notification_id": schema.StringAttribute{
@@ -101,6 +101,22 @@ func (d *BackupAndDrApplicationsDataSource) Schema(ctx context.Context, req data
 						},
 						"restore_instructions": schema.StringAttribute{
 							MarkdownDescription: "Restore instructions",
+							Computed:            true,
+						},
+						"target_account": schema.StringAttribute{
+							MarkdownDescription: "Target account/integration ID where the restore should land",
+							Computed:            true,
+						},
+						"target_region": schema.StringAttribute{
+							MarkdownDescription: "Target region where the restore should land",
+							Computed:            true,
+						},
+						"auto_create_pr": schema.BoolAttribute{
+							MarkdownDescription: "If true, the restore flow automatically opens a VCS pull request",
+							Computed:            true,
+						},
+						"resilience_enabled": schema.BoolAttribute{
+							MarkdownDescription: "When true, DR scheduling applies",
 							Computed:            true,
 						},
 						"status": schema.StringAttribute{
@@ -199,7 +215,7 @@ func (d *BackupAndDrApplicationsDataSource) Read(ctx context.Context, req dataso
 	})
 
 	// Get policies
-	policies, err := d.client.BackupAndDr.List(filters)
+	policies, err := d.client.BackupAndDr.List(accountID, filters)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading backup applications",
@@ -212,32 +228,29 @@ func (d *BackupAndDrApplicationsDataSource) Read(ctx context.Context, req dataso
 	data.Applications = make([]BackupAndDrApplicationDataSourceModel, len(policies.Data))
 	for i, policy := range policies.Data {
 		policyModel := BackupAndDrApplicationDataSourceModel{
-			ApplicationID:    types.StringValue(policy.PolicyID),
-			AccountID:        types.StringValue(policy.AccountID),
-			ApplicationName:  types.StringValue(policy.PolicyName),
-			IntegrationID:     types.StringValue(policy.IntegrationID),
-			Region:            types.StringValue(policy.Region),
-			ProviderType:      types.StringValue(policy.ProviderType),
-			ScheduleFrequency: types.StringValue(policy.Schedule.Frequency),
-			Status:            types.StringValue(policy.Status),
-			SnapshotsCount:    types.Int64Value(int64(policy.SnapshotsCount)),
-			CreatedAt:         types.StringValue(policy.CreatedAt),
-			UpdatedAt:         types.StringValue(policy.UpdatedAt),
+			ApplicationID:   types.StringValue(policy.PolicyID),
+			AccountID:       types.StringValue(policy.AccountID),
+			ApplicationName: types.StringValue(policy.PolicyName),
+			IntegrationID:   types.StringValue(policy.IntegrationID),
+			Region:          types.StringValue(policy.Region),
+			ProviderType:    types.StringValue(policy.ProviderType),
+			Frequency:       types.Int64Value(int64(policy.Frequency)),
+			AutoCreatePR:    types.BoolValue(policy.AutoCreatePR),
+			ResilienceEnabled: types.BoolValue(policy.ResilienceEnabled),
+			Status:          types.StringValue(policy.Status),
+			SnapshotsCount:  types.Int64Value(int64(policy.SnapshotsCount)),
+			CreatedAt:       types.StringValue(policy.CreatedAt),
+			UpdatedAt:       types.StringValue(policy.UpdatedAt),
 		}
 
-		// Optional string fields
 		policyModel.Description = StringValueOrNull(policy.Description)
-
 		policyModel.NotificationID = StringValueOrNull(policy.NotificationID)
-
 		policyModel.RestoreInstructions = StringValueOrNull(policy.RestoreInstructions)
-
+		policyModel.TargetAccount = StringValueOrNull(policy.TargetAccount)
+		policyModel.TargetRegion = StringValueOrNull(policy.TargetRegion)
 		policyModel.LastBackupSnapshotID = StringValueOrNull(policy.LastBackupSnapshotID)
-
 		policyModel.LastBackupTime = StringValueOrNull(policy.LastBackupTime)
-
 		policyModel.LastBackupStatus = StringValueOrNull(policy.LastBackupStatus)
-
 		policyModel.NextBackupTime = StringValueOrNull(policy.NextBackupTime)
 
 		data.Applications[i] = policyModel

--- a/internal/provider/data_source_backup_and_dr_applications.go
+++ b/internal/provider/data_source_backup_and_dr_applications.go
@@ -215,7 +215,7 @@ func (d *BackupAndDrApplicationsDataSource) Read(ctx context.Context, req dataso
 	})
 
 	// Get policies
-	policies, err := d.client.BackupAndDr.List(accountID, filters)
+	policies, err := d.client.BackupAndDr.List(filters)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading backup applications",

--- a/internal/provider/resource_backup_and_dr_application.go
+++ b/internal/provider/resource_backup_and_dr_application.go
@@ -261,7 +261,7 @@ func (r *BackupAndDrApplicationResource) Create(ctx context.Context, req resourc
 	})
 
 	// Create the policy
-	createdPolicy, err := r.client.BackupAndDr.Create(data.AccountID.ValueString(), request)
+	createdPolicy, err := r.client.BackupAndDr.Create(request)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating backup application",
@@ -306,7 +306,7 @@ func (r *BackupAndDrApplicationResource) Read(ctx context.Context, req resource.
 	})
 
 	// Get the policy
-	policy, err := r.client.BackupAndDr.Get(data.AccountID.ValueString(), policyID)
+	policy, err := r.client.BackupAndDr.Get(policyID)
 	if err != nil {
 		errorMsg := err.Error()
 		if strings.Contains(errorMsg, "policy not found") ||
@@ -371,7 +371,7 @@ func (r *BackupAndDrApplicationResource) Update(ctx context.Context, req resourc
 	updateRequest := client.ConvertCreateToUpdate(request)
 
 	// Update the policy
-	updatedPolicy, err := r.client.BackupAndDr.Update(data.AccountID.ValueString(), policyID, updateRequest)
+	updatedPolicy, err := r.client.BackupAndDr.Update(policyID, updateRequest)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating backup application",
@@ -415,7 +415,7 @@ func (r *BackupAndDrApplicationResource) Delete(ctx context.Context, req resourc
 		"policy_id":  policyID,
 	})
 
-	err := r.client.BackupAndDr.Delete(data.AccountID.ValueString(), policyID)
+	err := r.client.BackupAndDr.Delete(policyID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting backup application",

--- a/internal/provider/resource_backup_and_dr_application.go
+++ b/internal/provider/resource_backup_and_dr_application.go
@@ -95,6 +95,14 @@ func (r *BackupAndDrApplicationResource) Schema(ctx context.Context, req resourc
 					stringvalidator.LengthAtMost(500),
 				},
 			},
+			"frequency": schema.Int64Attribute{
+				MarkdownDescription: "Hours between scheduled backups (4, 8, 16, or 24)",
+				Optional:            true,
+				Computed:            true,
+				Validators: []validator.Int64{
+					int64validator.OneOf(4, 8, 16, 24),
+				},
+			},
 			"notification_id": schema.StringAttribute{
 				MarkdownDescription: "Notification channel ID for backup alerts",
 				Optional:            true,
@@ -111,6 +119,26 @@ func (r *BackupAndDrApplicationResource) Schema(ctx context.Context, req resourc
 				Optional:            true,
 				Computed:            true,
 				Default:             booldefault.StaticBool(true),
+			},
+			"target_account": schema.StringAttribute{
+				MarkdownDescription: "Target account/integration ID where the restore should land",
+				Optional:            true,
+				Computed:            true,
+			},
+			"target_region": schema.StringAttribute{
+				MarkdownDescription: "Target region where the restore should land",
+				Optional:            true,
+				Computed:            true,
+			},
+			"auto_create_pr": schema.BoolAttribute{
+				MarkdownDescription: "If true, the restore flow automatically opens a VCS pull request with the restored IaC",
+				Optional:            true,
+				Computed:            true,
+			},
+			"resilience_enabled": schema.BoolAttribute{
+				MarkdownDescription: "When true, target_account, target_region, and frequency are required and DR scheduling applies",
+				Optional:            true,
+				Computed:            true,
 			},
 			// Computed fields
 			"status": schema.StringAttribute{
@@ -151,70 +179,6 @@ func (r *BackupAndDrApplicationResource) Schema(ctx context.Context, req resourc
 		},
 
 		Blocks: map[string]schema.Block{
-			"schedule": schema.SingleNestedBlock{
-				MarkdownDescription: "Backup schedule configuration",
-				Attributes: map[string]schema.Attribute{
-					"frequency": schema.StringAttribute{
-						MarkdownDescription: "Backup frequency (One-time, Daily, Weekly, Monthly)",
-						Required:            true,
-						Validators: []validator.String{
-							stringvalidator.OneOf("One-time", "Daily", "Weekly", "Monthly"),
-						},
-					},
-					"hour": schema.Int64Attribute{
-						MarkdownDescription: "Hour of day for backup (0-23)",
-						Optional:            true,
-						Validators: []validator.Int64{
-							int64validator.Between(0, 23),
-						},
-					},
-					"minute": schema.Int64Attribute{
-						MarkdownDescription: "Minute of hour for backup (0-59)",
-						Optional:            true,
-						Validators: []validator.Int64{
-							int64validator.Between(0, 59),
-						},
-					},
-					"days_of_week": schema.ListAttribute{
-						ElementType:         types.StringType,
-						MarkdownDescription: "Days of week for Weekly schedule (e.g., ['Monday', 'Friday'])",
-						Optional:            true,
-						Validators: []validator.List{
-							listvalidator.SizeAtLeast(1),
-						},
-					},
-					"monthly_schedule_type": schema.StringAttribute{
-						MarkdownDescription: "Type of monthly schedule (specific_day, specific_weekday, last_day)",
-						Optional:            true,
-						Validators: []validator.String{
-							stringvalidator.OneOf("specific_day", "specific_weekday", "last_day"),
-						},
-					},
-					"day_of_month": schema.Int64Attribute{
-						MarkdownDescription: "Day of month for specific_day monthly schedule (1-31)",
-						Optional:            true,
-						Validators: []validator.Int64{
-							int64validator.Between(1, 31),
-						},
-					},
-					"weekday_ordinal": schema.StringAttribute{
-						MarkdownDescription: "Weekday ordinal for specific_weekday monthly schedule (First, Second, Third, Fourth, Last)",
-						Optional:            true,
-						Validators: []validator.String{
-							stringvalidator.OneOf("First", "Second", "Third", "Fourth", "Last"),
-						},
-					},
-					"weekday_name": schema.StringAttribute{
-						MarkdownDescription: "Weekday name for specific_weekday monthly schedule (e.g., 'Sunday')",
-						Optional:            true,
-					},
-					"cron_expression": schema.StringAttribute{
-						MarkdownDescription: "Cron expression as alternative to explicit schedule. If not provided, it may be computed by the server based on the schedule configuration.",
-						Optional:            true,
-						Computed:            true,
-					},
-				},
-			},
 			"scope": schema.ListNestedBlock{
 				MarkdownDescription: "Resource scope configurations for backup targeting",
 				NestedObject: schema.NestedBlockObject{
@@ -240,10 +204,6 @@ func (r *BackupAndDrApplicationResource) Schema(ctx context.Context, req resourc
 			"vcs": schema.SingleNestedBlock{
 				MarkdownDescription: "VCS integration configuration for backup artifacts",
 				Attributes: map[string]schema.Attribute{
-					"project_id": schema.StringAttribute{
-						MarkdownDescription: "Project ID for VCS integration",
-						Optional:            true,
-					},
 					"vcs_integration_id": schema.StringAttribute{
 						MarkdownDescription: "VCS integration ID",
 						Optional:            true,
@@ -301,7 +261,7 @@ func (r *BackupAndDrApplicationResource) Create(ctx context.Context, req resourc
 	})
 
 	// Create the policy
-	createdPolicy, err := r.client.BackupAndDr.Create(request)
+	createdPolicy, err := r.client.BackupAndDr.Create(data.AccountID.ValueString(), request)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating backup application",
@@ -346,7 +306,7 @@ func (r *BackupAndDrApplicationResource) Read(ctx context.Context, req resource.
 	})
 
 	// Get the policy
-	policy, err := r.client.BackupAndDr.Get(policyID)
+	policy, err := r.client.BackupAndDr.Get(data.AccountID.ValueString(), policyID)
 	if err != nil {
 		errorMsg := err.Error()
 		if strings.Contains(errorMsg, "policy not found") ||
@@ -411,7 +371,7 @@ func (r *BackupAndDrApplicationResource) Update(ctx context.Context, req resourc
 	updateRequest := client.ConvertCreateToUpdate(request)
 
 	// Update the policy
-	updatedPolicy, err := r.client.BackupAndDr.Update(policyID, updateRequest)
+	updatedPolicy, err := r.client.BackupAndDr.Update(data.AccountID.ValueString(), policyID, updateRequest)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating backup application",
@@ -455,7 +415,7 @@ func (r *BackupAndDrApplicationResource) Delete(ctx context.Context, req resourc
 		"policy_id":  policyID,
 	})
 
-	err := r.client.BackupAndDr.Delete(policyID)
+	err := r.client.BackupAndDr.Delete(data.AccountID.ValueString(), policyID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting backup application",

--- a/internal/provider/resource_backup_and_dr_application_models.go
+++ b/internal/provider/resource_backup_and_dr_application_models.go
@@ -7,19 +7,23 @@ import (
 // BackupAndDrApplicationResourceModel represents the resource model for a backup and DR application
 type BackupAndDrApplicationResourceModel struct {
 	// User-provided fields
-	ID                  types.String   `tfsdk:"id"`                    // computed (application_id)
-	AccountID           types.String   `tfsdk:"account_id"`            // required
-	ApplicationName     types.String   `tfsdk:"application_name"`      // required
-	IntegrationID       types.String   `tfsdk:"integration_id"`        // required
-	Region              types.String   `tfsdk:"region"`                // required
-	ProviderType        types.String   `tfsdk:"provider_type"`         // required
-	Description         types.String   `tfsdk:"description"`           // optional
-	Schedule            *ScheduleModel `tfsdk:"schedule"`              // required block
-	Scope               []ScopeModel   `tfsdk:"scope"`                 // optional list
-	NotificationID      types.String   `tfsdk:"notification_id"`       // optional
-	VCS                 *VCSModel      `tfsdk:"vcs"`                   // optional block
-	RestoreInstructions types.String   `tfsdk:"restore_instructions"`  // optional
-	BackupOnSave        types.Bool     `tfsdk:"backup_on_save"`        // optional, default true
+	ID                  types.String `tfsdk:"id"`                   // computed (application_id)
+	AccountID           types.String `tfsdk:"account_id"`           // required
+	ApplicationName     types.String `tfsdk:"application_name"`     // required
+	IntegrationID       types.String `tfsdk:"integration_id"`       // required
+	Region              types.String `tfsdk:"region"`               // required
+	ProviderType        types.String `tfsdk:"provider_type"`        // required
+	Description         types.String `tfsdk:"description"`          // optional
+	Frequency           types.Int64  `tfsdk:"frequency"`            // optional: 4, 8, 16, or 24 hours
+	Scope               []ScopeModel `tfsdk:"scope"`                // optional list
+	NotificationID      types.String `tfsdk:"notification_id"`      // optional
+	VCS                 *VCSModel    `tfsdk:"vcs"`                  // optional block
+	RestoreInstructions types.String `tfsdk:"restore_instructions"` // optional
+	BackupOnSave        types.Bool   `tfsdk:"backup_on_save"`       // optional, default true
+	TargetAccount       types.String `tfsdk:"target_account"`       // optional
+	TargetRegion        types.String `tfsdk:"target_region"`        // optional
+	AutoCreatePR        types.Bool   `tfsdk:"auto_create_pr"`       // optional
+	ResilienceEnabled   types.Bool   `tfsdk:"resilience_enabled"`   // optional
 
 	// Computed fields (never user-provided)
 	Status               types.String `tfsdk:"status"`
@@ -32,19 +36,6 @@ type BackupAndDrApplicationResourceModel struct {
 	UpdatedAt            types.String `tfsdk:"updated_at"`
 }
 
-// ScheduleModel represents the backup schedule configuration
-type ScheduleModel struct {
-	Frequency           types.String `tfsdk:"frequency"`               // required: One-time, Daily, Weekly, Monthly
-	Hour                types.Int64  `tfsdk:"hour"`                    // optional: 0-23
-	Minute              types.Int64  `tfsdk:"minute"`                  // optional: 0-59
-	DaysOfWeek          types.List   `tfsdk:"days_of_week"`            // optional: required for Weekly
-	MonthlyScheduleType types.String `tfsdk:"monthly_schedule_type"`   // optional: specific_day, specific_weekday, last_day
-	DayOfMonth          types.Int64  `tfsdk:"day_of_month"`            // optional: 1-31, required for Monthly specific_day
-	WeekdayOrdinal      types.String `tfsdk:"weekday_ordinal"`         // optional: First, Second, Third, Fourth, Last
-	WeekdayName         types.String `tfsdk:"weekday_name"`            // optional: required for Monthly specific_weekday
-	CronExpression      types.String `tfsdk:"cron_expression"`         // optional: alternative to explicit schedule
-}
-
 // ScopeModel represents a resource scope configuration
 type ScopeModel struct {
 	Type  types.String `tfsdk:"type"`  // required: tags, resource_group, asset_types, excluded_asset_types, selected_resources, excluded_resources
@@ -53,13 +44,12 @@ type ScopeModel struct {
 
 // VCSModel represents VCS integration configuration
 type VCSModel struct {
-	ProjectID        types.String `tfsdk:"project_id"`         // optional
 	VCSIntegrationID types.String `tfsdk:"vcs_integration_id"` // optional
 	RepoID           types.String `tfsdk:"repo_id"`            // optional
 }
 
 // BackupAndDrApplicationDataSourceModel represents the data source model for a single application
-// Note: Simplified schema without nested blocks (schedule, scope, vcs) to comply with data source limitations
+// Note: Simplified schema without nested blocks (scope, vcs) to comply with data source limitations
 type BackupAndDrApplicationDataSourceModel struct {
 	ApplicationID        types.String `tfsdk:"application_id"`
 	AccountID            types.String `tfsdk:"account_id"`
@@ -68,9 +58,13 @@ type BackupAndDrApplicationDataSourceModel struct {
 	Region               types.String `tfsdk:"region"`
 	ProviderType         types.String `tfsdk:"provider_type"`
 	Description          types.String `tfsdk:"description"`
-	ScheduleFrequency    types.String `tfsdk:"schedule_frequency"` // Simplified: only showing frequency
+	Frequency            types.Int64  `tfsdk:"frequency"`
 	NotificationID       types.String `tfsdk:"notification_id"`
 	RestoreInstructions  types.String `tfsdk:"restore_instructions"`
+	TargetAccount        types.String `tfsdk:"target_account"`
+	TargetRegion         types.String `tfsdk:"target_region"`
+	AutoCreatePR         types.Bool   `tfsdk:"auto_create_pr"`
+	ResilienceEnabled    types.Bool   `tfsdk:"resilience_enabled"`
 	Status               types.String `tfsdk:"status"`
 	SnapshotsCount       types.Int64  `tfsdk:"snapshots_count"`
 	LastBackupSnapshotID types.String `tfsdk:"last_backup_snapshot_id"`

--- a/internal/provider/resource_backup_and_dr_application_operations.go
+++ b/internal/provider/resource_backup_and_dr_application_operations.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gofireflyio/terraform-provider-firefly/internal/client"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -20,65 +19,18 @@ func StringValueOrNull(s string) types.String {
 
 // mapModelToAPIRequest converts the Terraform model to an API request
 func mapModelToAPIRequest(ctx context.Context, model *BackupAndDrApplicationResourceModel) (*client.PolicyCreateRequest, error) {
-	// Validate schedule first
-	if model.Schedule == nil {
-		return nil, fmt.Errorf("schedule is required")
-	}
-
-	if err := validateScheduleConfig(model.Schedule); err != nil {
-		return nil, err
-	}
-
-	// Build schedule config
-	schedule := client.ScheduleConfig{
-		Frequency: model.Schedule.Frequency.ValueString(),
-	}
-
-	if !model.Schedule.Hour.IsNull() {
-		schedule.Hour = int(model.Schedule.Hour.ValueInt64())
-	}
-
-	if !model.Schedule.Minute.IsNull() {
-		schedule.Minute = int(model.Schedule.Minute.ValueInt64())
-	}
-
-	if !model.Schedule.DaysOfWeek.IsNull() {
-		var daysOfWeek []string
-		model.Schedule.DaysOfWeek.ElementsAs(ctx, &daysOfWeek, false)
-		schedule.DaysOfWeek = daysOfWeek
-	}
-
-	if !model.Schedule.MonthlyScheduleType.IsNull() {
-		schedule.MonthlyScheduleType = model.Schedule.MonthlyScheduleType.ValueString()
-	}
-
-	if !model.Schedule.DayOfMonth.IsNull() {
-		schedule.DayOfMonth = int(model.Schedule.DayOfMonth.ValueInt64())
-	}
-
-	if !model.Schedule.WeekdayOrdinal.IsNull() {
-		schedule.WeekdayOrdinal = model.Schedule.WeekdayOrdinal.ValueString()
-	}
-
-	if !model.Schedule.WeekdayName.IsNull() {
-		schedule.WeekdayName = model.Schedule.WeekdayName.ValueString()
-	}
-
-	if !model.Schedule.CronExpression.IsNull() {
-		schedule.CronExpression = model.Schedule.CronExpression.ValueString()
-	}
-
-	// Build base request
 	request := &client.PolicyCreateRequest{
 		PolicyName:    model.ApplicationName.ValueString(),
 		IntegrationID: model.IntegrationID.ValueString(),
 		Region:        model.Region.ValueString(),
 		ProviderType:  model.ProviderType.ValueString(),
-		Schedule:      schedule,
 		BackupOnSave:  true, // Default value
 	}
 
-	// Optional fields
+	if !model.Frequency.IsNull() {
+		request.Frequency = int(model.Frequency.ValueInt64())
+	}
+
 	if !model.Description.IsNull() {
 		request.Description = model.Description.ValueString()
 	}
@@ -93,6 +45,22 @@ func mapModelToAPIRequest(ctx context.Context, model *BackupAndDrApplicationReso
 
 	if !model.RestoreInstructions.IsNull() {
 		request.RestoreInstructions = model.RestoreInstructions.ValueString()
+	}
+
+	if !model.TargetAccount.IsNull() {
+		request.TargetAccount = model.TargetAccount.ValueString()
+	}
+
+	if !model.TargetRegion.IsNull() {
+		request.TargetRegion = model.TargetRegion.ValueString()
+	}
+
+	if !model.AutoCreatePR.IsNull() {
+		request.AutoCreatePR = model.AutoCreatePR.ValueBool()
+	}
+
+	if !model.ResilienceEnabled.IsNull() {
+		request.ResilienceEnabled = model.ResilienceEnabled.ValueBool()
 	}
 
 	// Build scope array
@@ -112,10 +80,6 @@ func mapModelToAPIRequest(ctx context.Context, model *BackupAndDrApplicationReso
 	// Build VCS config
 	if model.VCS != nil {
 		vcs := &client.VCSConfig{}
-
-		if !model.VCS.ProjectID.IsNull() {
-			vcs.ProjectID = model.VCS.ProjectID.ValueString()
-		}
 
 		if !model.VCS.VCSIntegrationID.IsNull() {
 			vcs.VCSIntegrationID = model.VCS.VCSIntegrationID.ValueString()
@@ -145,49 +109,15 @@ func mapAPIResponseToModel(response *client.PolicyResponse, model *BackupAndDrAp
 	model.ProviderType = types.StringValue(response.ProviderType)
 
 	model.Description = StringValueOrNull(response.Description)
-
 	model.NotificationID = StringValueOrNull(response.NotificationID)
-
 	model.RestoreInstructions = StringValueOrNull(response.RestoreInstructions)
 
-	// Update schedule (always present)
-	scheduleModel := &ScheduleModel{
-		Frequency: types.StringValue(response.Schedule.Frequency),
-	}
+	model.Frequency = types.Int64Value(int64(response.Frequency))
 
-	if response.Schedule.Hour != 0 || response.Schedule.Minute != 0 {
-		scheduleModel.Hour = types.Int64Value(int64(response.Schedule.Hour))
-		scheduleModel.Minute = types.Int64Value(int64(response.Schedule.Minute))
-	} else {
-		scheduleModel.Hour = types.Int64Null()
-		scheduleModel.Minute = types.Int64Null()
-	}
-
-	if len(response.Schedule.DaysOfWeek) > 0 {
-		daysValues := make([]attr.Value, len(response.Schedule.DaysOfWeek))
-		for i, day := range response.Schedule.DaysOfWeek {
-			daysValues[i] = types.StringValue(day)
-		}
-		scheduleModel.DaysOfWeek = types.ListValueMust(types.StringType, daysValues)
-	} else {
-		scheduleModel.DaysOfWeek = types.ListNull(types.StringType)
-	}
-
-	scheduleModel.MonthlyScheduleType = StringValueOrNull(response.Schedule.MonthlyScheduleType)
-
-	if response.Schedule.DayOfMonth != 0 {
-		scheduleModel.DayOfMonth = types.Int64Value(int64(response.Schedule.DayOfMonth))
-	} else {
-		scheduleModel.DayOfMonth = types.Int64Null()
-	}
-
-	scheduleModel.WeekdayOrdinal = StringValueOrNull(response.Schedule.WeekdayOrdinal)
-
-	scheduleModel.WeekdayName = StringValueOrNull(response.Schedule.WeekdayName)
-
-	scheduleModel.CronExpression = StringValueOrNull(response.Schedule.CronExpression)
-
-	model.Schedule = scheduleModel
+	model.TargetAccount = StringValueOrNull(response.TargetAccount)
+	model.TargetRegion = StringValueOrNull(response.TargetRegion)
+	model.AutoCreatePR = types.BoolValue(response.AutoCreatePR)
+	model.ResilienceEnabled = types.BoolValue(response.ResilienceEnabled)
 
 	// Update scope array
 	if len(response.Scope) > 0 {
@@ -210,13 +140,8 @@ func mapAPIResponseToModel(response *client.PolicyResponse, model *BackupAndDrAp
 	// Update VCS config
 	if response.VCS != nil {
 		vcsModel := &VCSModel{}
-
-		vcsModel.ProjectID = StringValueOrNull(response.VCS.ProjectID)
-
 		vcsModel.VCSIntegrationID = StringValueOrNull(response.VCS.VCSIntegrationID)
-
 		vcsModel.RepoID = StringValueOrNull(response.VCS.RepoID)
-
 		model.VCS = vcsModel
 	} else {
 		model.VCS = nil
@@ -227,74 +152,12 @@ func mapAPIResponseToModel(response *client.PolicyResponse, model *BackupAndDrAp
 	model.SnapshotsCount = types.Int64Value(int64(response.SnapshotsCount))
 
 	model.LastBackupSnapshotID = StringValueOrNull(response.LastBackupSnapshotID)
-
 	model.LastBackupTime = StringValueOrNull(response.LastBackupTime)
-
 	model.LastBackupStatus = StringValueOrNull(response.LastBackupStatus)
-
 	model.NextBackupTime = StringValueOrNull(response.NextBackupTime)
 
 	model.CreatedAt = types.StringValue(response.CreatedAt)
 	model.UpdatedAt = types.StringValue(response.UpdatedAt)
 
 	return nil
-}
-
-// validateScheduleConfig validates the schedule configuration based on frequency
-func validateScheduleConfig(schedule *ScheduleModel) error {
-	frequency := schedule.Frequency.ValueString()
-
-	switch frequency {
-	case "One-time", "Daily":
-		// No special validation needed
-		return nil
-
-	case "Weekly":
-		// Weekly requires days_of_week
-		if schedule.DaysOfWeek.IsNull() || len(schedule.DaysOfWeek.Elements()) == 0 {
-			return fmt.Errorf("weekly schedule requires days_of_week to be specified")
-		}
-		return nil
-
-	case "Monthly":
-		// Monthly requires monthly_schedule_type
-		if schedule.MonthlyScheduleType.IsNull() {
-			return fmt.Errorf("monthly schedule requires monthly_schedule_type to be specified")
-		}
-
-		scheduleType := schedule.MonthlyScheduleType.ValueString()
-
-		switch scheduleType {
-		case "specific_day":
-			// Requires day_of_month
-			if schedule.DayOfMonth.IsNull() {
-				return fmt.Errorf("monthly schedule with specific_day requires day_of_month to be specified")
-			}
-			dayOfMonth := schedule.DayOfMonth.ValueInt64()
-			if dayOfMonth < 1 || dayOfMonth > 31 {
-				return fmt.Errorf("day_of_month must be between 1 and 31, got %d", dayOfMonth)
-			}
-			return nil
-
-		case "specific_weekday":
-			// Requires weekday_ordinal and weekday_name
-			if schedule.WeekdayOrdinal.IsNull() {
-				return fmt.Errorf("monthly schedule with specific_weekday requires weekday_ordinal to be specified")
-			}
-			if schedule.WeekdayName.IsNull() {
-				return fmt.Errorf("monthly schedule with specific_weekday requires weekday_name to be specified")
-			}
-			return nil
-
-		case "last_day":
-			// No additional requirements
-			return nil
-
-		default:
-			return fmt.Errorf("invalid monthly_schedule_type: %s (must be specific_day, specific_weekday, or last_day)", scheduleType)
-		}
-
-	default:
-		return fmt.Errorf("invalid frequency: %s (must be One-time, Daily, Weekly, or Monthly)", frequency)
-	}
 }

--- a/internal/provider/resource_backup_and_dr_application_operations_test.go
+++ b/internal/provider/resource_backup_and_dr_application_operations_test.go
@@ -48,147 +48,19 @@ func TestStringValueOrNull_SingleCharacter(t *testing.T) {
 	}
 }
 
-// Unit tests for schedule validation
-
-func TestValidateScheduleConfig_Daily(t *testing.T) {
-	schedule := &ScheduleModel{
-		Frequency: types.StringValue("Daily"),
-		Hour:      types.Int64Value(2),
-		Minute:    types.Int64Value(30),
-	}
-
-	err := validateScheduleConfig(schedule)
-	if err != nil {
-		t.Errorf("Daily schedule validation failed: %v", err)
-	}
-}
-
-func TestValidateScheduleConfig_Weekly_Valid(t *testing.T) {
-	daysOfWeek := []attr.Value{
-		types.StringValue("Monday"),
-		types.StringValue("Friday"),
-	}
-
-	schedule := &ScheduleModel{
-		Frequency:  types.StringValue("Weekly"),
-		DaysOfWeek: types.ListValueMust(types.StringType, daysOfWeek),
-		Hour:       types.Int64Value(2),
-		Minute:     types.Int64Value(30),
-	}
-
-	err := validateScheduleConfig(schedule)
-	if err != nil {
-		t.Errorf("Weekly schedule validation failed: %v", err)
-	}
-}
-
-func TestValidateScheduleConfig_Weekly_MissingDays(t *testing.T) {
-	schedule := &ScheduleModel{
-		Frequency:  types.StringValue("Weekly"),
-		DaysOfWeek: types.ListNull(types.StringType),
-		Hour:       types.Int64Value(2),
-		Minute:     types.Int64Value(30),
-	}
-
-	err := validateScheduleConfig(schedule)
-	if err == nil {
-		t.Error("Expected error for Weekly schedule without days_of_week, got nil")
-	}
-
-	expectedMsg := "weekly schedule requires days_of_week to be specified"
-	if err.Error() != expectedMsg {
-		t.Errorf("Expected error message %q, got %q", expectedMsg, err.Error())
-	}
-}
-
-func TestValidateScheduleConfig_Monthly_SpecificDay(t *testing.T) {
-	schedule := &ScheduleModel{
-		Frequency:           types.StringValue("Monthly"),
-		MonthlyScheduleType: types.StringValue("specific_day"),
-		DayOfMonth:          types.Int64Value(15),
-		Hour:                types.Int64Value(3),
-		Minute:              types.Int64Value(0),
-	}
-
-	err := validateScheduleConfig(schedule)
-	if err != nil {
-		t.Errorf("Monthly specific_day validation failed: %v", err)
-	}
-}
-
-func TestValidateScheduleConfig_Monthly_SpecificDay_Invalid(t *testing.T) {
-	schedule := &ScheduleModel{
-		Frequency:           types.StringValue("Monthly"),
-		MonthlyScheduleType: types.StringValue("specific_day"),
-		DayOfMonth:          types.Int64Value(32),
-		Hour:                types.Int64Value(3),
-		Minute:              types.Int64Value(0),
-	}
-
-	err := validateScheduleConfig(schedule)
-	if err == nil {
-		t.Error("Expected error for day_of_month > 31, got nil")
-	}
-}
-
-func TestValidateScheduleConfig_Monthly_SpecificWeekday(t *testing.T) {
-	schedule := &ScheduleModel{
-		Frequency:           types.StringValue("Monthly"),
-		MonthlyScheduleType: types.StringValue("specific_weekday"),
-		WeekdayOrdinal:      types.StringValue("First"),
-		WeekdayName:         types.StringValue("Sunday"),
-		Hour:                types.Int64Value(3),
-		Minute:              types.Int64Value(0),
-	}
-
-	err := validateScheduleConfig(schedule)
-	if err != nil {
-		t.Errorf("Monthly specific_weekday validation failed: %v", err)
-	}
-}
-
-func TestValidateScheduleConfig_Monthly_MissingType(t *testing.T) {
-	schedule := &ScheduleModel{
-		Frequency:           types.StringValue("Monthly"),
-		MonthlyScheduleType: types.StringNull(),
-		Hour:                types.Int64Value(3),
-		Minute:              types.Int64Value(0),
-	}
-
-	err := validateScheduleConfig(schedule)
-	if err == nil {
-		t.Error("Expected error for Monthly without monthly_schedule_type, got nil")
-	}
-}
-
-func TestValidateScheduleConfig_InvalidFrequency(t *testing.T) {
-	schedule := &ScheduleModel{
-		Frequency: types.StringValue("Yearly"),
-	}
-
-	err := validateScheduleConfig(schedule)
-	if err == nil {
-		t.Error("Expected error for invalid frequency, got nil")
-	}
-}
-
 // Unit tests for model to API conversion
 
-func TestMapModelToAPIRequest_Daily(t *testing.T) {
+func TestMapModelToAPIRequest_WithFrequency(t *testing.T) {
 	ctx := context.Background()
 	model := &BackupAndDrApplicationResourceModel{
-		AccountID:     types.StringValue("test-account"),
-		ApplicationName:    types.StringValue("Test Policy"),
-		IntegrationID: types.StringValue("int-123"),
-		Region:        types.StringValue("us-east-1"),
-		ProviderType:  types.StringValue("aws"),
-		Description:   types.StringValue("Test description"),
-		BackupOnSave:  types.BoolValue(true),
-		Schedule: &ScheduleModel{
-			Frequency: types.StringValue("Daily"),
-			Hour:      types.Int64Value(2),
-			Minute:    types.Int64Value(30),
-		},
+		AccountID:       types.StringValue("test-account"),
+		ApplicationName: types.StringValue("Test Policy"),
+		IntegrationID:   types.StringValue("int-123"),
+		Region:          types.StringValue("us-east-1"),
+		ProviderType:    types.StringValue("aws"),
+		Description:     types.StringValue("Test description"),
+		BackupOnSave:    types.BoolValue(true),
+		Frequency:       types.Int64Value(24),
 	}
 
 	request, err := mapModelToAPIRequest(ctx, model)
@@ -200,20 +72,33 @@ func TestMapModelToAPIRequest_Daily(t *testing.T) {
 		t.Errorf("Expected PolicyName 'Test Policy', got '%s'", request.PolicyName)
 	}
 
-	if request.Schedule.Frequency != "Daily" {
-		t.Errorf("Expected Frequency 'Daily', got '%s'", request.Schedule.Frequency)
-	}
-
-	if request.Schedule.Hour != 2 {
-		t.Errorf("Expected Hour 2, got %d", request.Schedule.Hour)
-	}
-
-	if request.Schedule.Minute != 30 {
-		t.Errorf("Expected Minute 30, got %d", request.Schedule.Minute)
+	if request.Frequency != 24 {
+		t.Errorf("Expected Frequency 24, got %d", request.Frequency)
 	}
 
 	if !request.BackupOnSave {
 		t.Error("Expected BackupOnSave true, got false")
+	}
+}
+
+func TestMapModelToAPIRequest_FrequencyNull(t *testing.T) {
+	ctx := context.Background()
+	model := &BackupAndDrApplicationResourceModel{
+		AccountID:       types.StringValue("test-account"),
+		ApplicationName: types.StringValue("No Frequency Policy"),
+		IntegrationID:   types.StringValue("int-123"),
+		Region:          types.StringValue("us-east-1"),
+		ProviderType:    types.StringValue("aws"),
+		Frequency:       types.Int64Null(),
+	}
+
+	request, err := mapModelToAPIRequest(ctx, model)
+	if err != nil {
+		t.Fatalf("mapModelToAPIRequest failed: %v", err)
+	}
+
+	if request.Frequency != 0 {
+		t.Errorf("Expected Frequency 0 (not set), got %d", request.Frequency)
 	}
 }
 
@@ -231,16 +116,12 @@ func TestMapModelToAPIRequest_WithScope(t *testing.T) {
 	}
 
 	model := &BackupAndDrApplicationResourceModel{
-		AccountID:     types.StringValue("test-account"),
-		ApplicationName:    types.StringValue("Scoped Policy"),
-		IntegrationID: types.StringValue("int-123"),
-		Region:        types.StringValue("us-east-1"),
-		ProviderType:  types.StringValue("aws"),
-		Schedule: &ScheduleModel{
-			Frequency: types.StringValue("Daily"),
-			Hour:      types.Int64Value(2),
-			Minute:    types.Int64Value(0),
-		},
+		AccountID:       types.StringValue("test-account"),
+		ApplicationName: types.StringValue("Scoped Policy"),
+		IntegrationID:   types.StringValue("int-123"),
+		Region:          types.StringValue("us-east-1"),
+		ProviderType:    types.StringValue("aws"),
+		Frequency:       types.Int64Value(8),
 		Scope: []ScopeModel{
 			{
 				Type:  types.StringValue("tags"),
@@ -278,18 +159,13 @@ func TestMapModelToAPIRequest_WithScope(t *testing.T) {
 func TestMapModelToAPIRequest_WithVCS(t *testing.T) {
 	ctx := context.Background()
 	model := &BackupAndDrApplicationResourceModel{
-		AccountID:     types.StringValue("test-account"),
-		ApplicationName:    types.StringValue("VCS Policy"),
-		IntegrationID: types.StringValue("int-123"),
-		Region:        types.StringValue("us-east-1"),
-		ProviderType:  types.StringValue("aws"),
-		Schedule: &ScheduleModel{
-			Frequency: types.StringValue("Daily"),
-			Hour:      types.Int64Value(2),
-			Minute:    types.Int64Value(0),
-		},
+		AccountID:       types.StringValue("test-account"),
+		ApplicationName: types.StringValue("VCS Policy"),
+		IntegrationID:   types.StringValue("int-123"),
+		Region:          types.StringValue("us-east-1"),
+		ProviderType:    types.StringValue("aws"),
+		Frequency:       types.Int64Value(24),
 		VCS: &VCSModel{
-			ProjectID:        types.StringValue("project-123"),
 			VCSIntegrationID: types.StringValue("github-456"),
 			RepoID:           types.StringValue("repo-789"),
 		},
@@ -304,16 +180,49 @@ func TestMapModelToAPIRequest_WithVCS(t *testing.T) {
 		t.Fatal("Expected VCS config, got nil")
 	}
 
-	if request.VCS.ProjectID != "project-123" {
-		t.Errorf("Expected ProjectID 'project-123', got '%s'", request.VCS.ProjectID)
-	}
-
 	if request.VCS.VCSIntegrationID != "github-456" {
 		t.Errorf("Expected VCSIntegrationID 'github-456', got '%s'", request.VCS.VCSIntegrationID)
 	}
 
 	if request.VCS.RepoID != "repo-789" {
 		t.Errorf("Expected RepoID 'repo-789', got '%s'", request.VCS.RepoID)
+	}
+}
+
+func TestMapModelToAPIRequest_WithResilienceFields(t *testing.T) {
+	ctx := context.Background()
+	model := &BackupAndDrApplicationResourceModel{
+		AccountID:         types.StringValue("test-account"),
+		ApplicationName:   types.StringValue("Resilience Policy"),
+		IntegrationID:     types.StringValue("int-123"),
+		Region:            types.StringValue("us-east-1"),
+		ProviderType:      types.StringValue("aws"),
+		Frequency:         types.Int64Value(4),
+		TargetAccount:     types.StringValue("target-int-456"),
+		TargetRegion:      types.StringValue("eu-west-1"),
+		AutoCreatePR:      types.BoolValue(true),
+		ResilienceEnabled: types.BoolValue(true),
+	}
+
+	request, err := mapModelToAPIRequest(ctx, model)
+	if err != nil {
+		t.Fatalf("mapModelToAPIRequest failed: %v", err)
+	}
+
+	if request.TargetAccount != "target-int-456" {
+		t.Errorf("Expected TargetAccount 'target-int-456', got '%s'", request.TargetAccount)
+	}
+
+	if request.TargetRegion != "eu-west-1" {
+		t.Errorf("Expected TargetRegion 'eu-west-1', got '%s'", request.TargetRegion)
+	}
+
+	if !request.AutoCreatePR {
+		t.Error("Expected AutoCreatePR true, got false")
+	}
+
+	if !request.ResilienceEnabled {
+		t.Error("Expected ResilienceEnabled true, got false")
 	}
 }
 
@@ -328,15 +237,11 @@ func TestMapAPIResponseToModel(t *testing.T) {
 		Region:         "us-east-1",
 		ProviderType:   "aws",
 		Description:    "Test description",
+		Frequency:      24,
 		Status:         "Active",
 		SnapshotsCount: 5,
-		Schedule: client.ScheduleConfig{
-			Frequency: "Daily",
-			Hour:      2,
-			Minute:    30,
-		},
-		CreatedAt: "2025-01-01T00:00:00Z",
-		UpdatedAt: "2025-01-01T10:00:00Z",
+		CreatedAt:      "2025-01-01T00:00:00Z",
+		UpdatedAt:      "2025-01-01T10:00:00Z",
 	}
 
 	model := &BackupAndDrApplicationResourceModel{}
@@ -365,12 +270,8 @@ func TestMapAPIResponseToModel(t *testing.T) {
 		t.Errorf("Expected SnapshotsCount 5, got %d", model.SnapshotsCount.ValueInt64())
 	}
 
-	if model.Schedule == nil {
-		t.Fatal("Expected schedule, got nil")
-	}
-
-	if model.Schedule.Frequency.ValueString() != "Daily" {
-		t.Errorf("Expected Frequency 'Daily', got '%s'", model.Schedule.Frequency.ValueString())
+	if model.Frequency.ValueInt64() != 24 {
+		t.Errorf("Expected Frequency 24, got %d", model.Frequency.ValueInt64())
 	}
 }
 
@@ -382,11 +283,7 @@ func TestMapAPIResponseToModel_WithScope(t *testing.T) {
 		IntegrationID: "int-789",
 		Region:        "us-east-1",
 		ProviderType:  "aws",
-		Schedule: client.ScheduleConfig{
-			Frequency: "Daily",
-			Hour:      2,
-			Minute:    0,
-		},
+		Frequency:     8,
 		Scope: []client.ScopeConfig{
 			{
 				Type:  "tags",
@@ -397,9 +294,9 @@ func TestMapAPIResponseToModel_WithScope(t *testing.T) {
 				Value: []string{"aws_instance"},
 			},
 		},
-		Status:     "Active",
-		CreatedAt:  "2025-01-01T00:00:00Z",
-		UpdatedAt:  "2025-01-01T10:00:00Z",
+		Status:    "Active",
+		CreatedAt: "2025-01-01T00:00:00Z",
+		UpdatedAt: "2025-01-01T10:00:00Z",
 	}
 
 	model := &BackupAndDrApplicationResourceModel{}
@@ -421,20 +318,59 @@ func TestMapAPIResponseToModel_WithScope(t *testing.T) {
 	}
 }
 
+func TestMapAPIResponseToModel_WithResilienceFields(t *testing.T) {
+	response := &client.PolicyResponse{
+		PolicyID:          "policy-123",
+		AccountID:         "account-456",
+		PolicyName:        "Resilience Policy",
+		IntegrationID:     "int-789",
+		Region:            "us-east-1",
+		ProviderType:      "aws",
+		Frequency:         4,
+		TargetAccount:     "target-int-456",
+		TargetRegion:      "eu-west-1",
+		AutoCreatePR:      true,
+		ResilienceEnabled: true,
+		Status:            "Active",
+		CreatedAt:         "2025-01-01T00:00:00Z",
+		UpdatedAt:         "2025-01-01T10:00:00Z",
+	}
+
+	model := &BackupAndDrApplicationResourceModel{}
+	err := mapAPIResponseToModel(response, model)
+	if err != nil {
+		t.Fatalf("mapAPIResponseToModel failed: %v", err)
+	}
+
+	if model.TargetAccount.ValueString() != "target-int-456" {
+		t.Errorf("Expected TargetAccount 'target-int-456', got '%s'", model.TargetAccount.ValueString())
+	}
+
+	if model.TargetRegion.ValueString() != "eu-west-1" {
+		t.Errorf("Expected TargetRegion 'eu-west-1', got '%s'", model.TargetRegion.ValueString())
+	}
+
+	if !model.AutoCreatePR.ValueBool() {
+		t.Error("Expected AutoCreatePR true, got false")
+	}
+
+	if !model.ResilienceEnabled.ValueBool() {
+		t.Error("Expected ResilienceEnabled true, got false")
+	}
+}
+
 func TestMapAPIResponseToModel_NullOptionalFields(t *testing.T) {
 	response := &client.PolicyResponse{
-		PolicyID:       "policy-123",
-		AccountID:      "account-456",
-		PolicyName:     "Minimal Policy",
-		IntegrationID:  "int-789",
-		Region:         "us-east-1",
-		ProviderType:   "aws",
-		Schedule: client.ScheduleConfig{
-			Frequency: "Daily",
-		},
-		Status:    "Active",
-		CreatedAt: "2025-01-01T00:00:00Z",
-		UpdatedAt: "2025-01-01T10:00:00Z",
+		PolicyID:      "policy-123",
+		AccountID:     "account-456",
+		PolicyName:    "Minimal Policy",
+		IntegrationID: "int-789",
+		Region:        "us-east-1",
+		ProviderType:  "aws",
+		Frequency:     0,
+		Status:        "Active",
+		CreatedAt:     "2025-01-01T00:00:00Z",
+		UpdatedAt:     "2025-01-01T10:00:00Z",
 		// All optional fields are empty
 	}
 
@@ -454,6 +390,14 @@ func TestMapAPIResponseToModel_NullOptionalFields(t *testing.T) {
 
 	if !model.LastBackupSnapshotID.IsNull() {
 		t.Error("Expected LastBackupSnapshotID to be null")
+	}
+
+	if !model.TargetAccount.IsNull() {
+		t.Error("Expected TargetAccount to be null")
+	}
+
+	if !model.TargetRegion.IsNull() {
+		t.Error("Expected TargetRegion to be null")
 	}
 
 	if model.Scope != nil {


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
- [ ] Bug fix
- [x] Feature
- [ ] Code maintenance
- [ ] Performance enhancement

* **Description of the changes included in this PR**

Updated the Backup & DR API client and Terraform resource/data source to align with the revised OpenAPI spec:

- **Simplified schedule**: removed the `ScheduleConfig` struct (frequency string + cron fields) and replaced it with a single `frequency int` (allowed values: 4, 8, 16, 24 hours)
- **New policy fields**: added `target_account`, `target_region`, `auto_create_pr`, and `resilience_enabled` to both the API client structs and Terraform schema
- **Simplified VCS config**: removed `project_id` from `VCSConfig`; only `vcs_integration_id` and `repo_id` remain

* **Does this PR introduce a breaking change?**
Yes — existing Terraform configs using `schedule { }` blocks must be updated to use `frequency = <int>` instead.

* **Please declare that your PR fulfills these requirements:**
- [x] Unit tests covering my changes are included
- [x] I successfully ran my code on my local setup
- [ ] This branch has been successfully deployed in a development environment
- [ ] This branch has been successfully deployed to staging environment
- [x] All required environment variables have been updated via ArgoCD
- [x] My code follows the project's style guidelines and has been linted
- [x] Documentation have been added / updated (please add a link)